### PR TITLE
Hardening flaky tests (phase 1)

### DIFF
--- a/tests/checkout.smoke.spec.ts
+++ b/tests/checkout.smoke.spec.ts
@@ -88,6 +88,16 @@ test.describe('Checkout Smoke', () => {
       }
     }
 
+    // Chờ điều hướng sang /checkout và trạng thái network ổn định trước khi assert
+    if (!page.isClosed()) {
+      try {
+        await expect(page).toHaveURL(/\/checkout/, { timeout: 10000 });
+      } catch {}
+      try {
+        await page.waitForLoadState('networkidle', { timeout: 5000 });
+      } catch {}
+    }
+
     // Trên trang Checkout
     await expect(page.getByTestId('checkout-page')).toBeVisible();
 

--- a/tests/recently-viewed.spec.ts
+++ b/tests/recently-viewed.spec.ts
@@ -22,9 +22,19 @@ test.describe('Recently Viewed - Product Detail', () => {
     await page.waitForLoadState('domcontentloaded');
     await removeSilktide(page);
 
+    // Chờ localStorage có dữ liệu recentlyViewed trước khi assert UI
+    await page.waitForFunction(() => {
+      try {
+        const rv = JSON.parse(localStorage.getItem('recentlyViewed') || '[]');
+        return Array.isArray(rv) && rv.length > 0;
+      } catch (e) {
+        return false;
+      }
+    }, { timeout: 15000 });
+
     // Recently viewed section should appear
     const rv = page.getByTestId('recently-viewed');
-    await expect(rv).toBeVisible({ timeout: 10000 });
+    await expect(rv).toBeVisible({ timeout: 15000 });
 
     // Should contain the first product title
     await expect(rv.locator('a', { hasText: 'Premium Japanese Sneakers' }).first()).toBeVisible();


### PR DESCRIPTION
Phase 1 hardening for flaky tests:\n- checkout.smoke: add URL/networkidle waits, guard page closure\n- recently-viewed: wait for localStorage recentlyViewed\n- wishlist add-to-cart: wait for localStorage simple-cart items then verify sidebar with fallback\n\nCI skips remain for now; next phase will unskip gradually after observing stability.