### PR TITLE
CI: Bump Node to 20.x in E2E workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: '20'
           cache: 'npm'
 
       - name: Install deps


### PR DESCRIPTION
Align Node version to 20.x for the E2E workflow to match @vitejs/plugin-react engine constraints.\n\nChanges\n- .github/workflows/e2e.yml: setup-node now uses node-version: '20'.\n\nWhy\n- Avoid EBADENGINE warnings and reduce risk of subtle runtime differences between local and CI.\n\nNotes\n- Other workflows already use Node 20 or run in a Playwright container; no changes needed there for now.