### PR TITLE
feat(ux+i18n): wishlist/cart local notices, VN toasts; enrich product content; localize ProductDetail UI

### DIFF
--- a/src/components/SimpleCartSidebar.tsx
+++ b/src/components/SimpleCartSidebar.tsx
@@ -68,6 +68,10 @@ export const SimpleCartSidebar: React.FC<SimpleCartSidebarProps> = ({
 
         {/* Content */}
         <div className="flex flex-col h-full">
+          {/* Local data notice */}
+          <div className="px-4 py-2 text-xs text-gray-500 bg-gray-50 border-b">
+            Lưu ý: Giỏ hàng được lưu cục bộ trên trình duyệt này.
+          </div>
           {items.length === 0 ? (
             /* Empty Cart */
             <div className="flex-1 flex flex-col items-center justify-center p-8 text-center">

--- a/src/contexts/SimpleCartContext.tsx
+++ b/src/contexts/SimpleCartContext.tsx
@@ -152,12 +152,12 @@ export const SimpleCartProvider: React.FC<{ children: React.ReactNode }> = ({ ch
         finalPrice: product.sellingPrice
       }
     });
-    toast.success(`Added ${product.name} to cart`);
+    toast.success(`Đã thêm ${product.name} vào giỏ hàng`);
   };
 
   const removeFromCart = (itemId: string) => {
     dispatch({ type: 'REMOVE_FROM_CART', payload: { itemId } });
-    toast.success('Removed from cart');
+    toast.success('Đã xóa khỏi giỏ hàng');
   };
 
   const updateQuantity = (itemId: string, quantity: number) => {
@@ -166,7 +166,7 @@ export const SimpleCartProvider: React.FC<{ children: React.ReactNode }> = ({ ch
 
   const clearCart = () => {
     dispatch({ type: 'CLEAR_CART' });
-    toast.success('Cart cleared');
+    toast.success('Đã xóa giỏ hàng');
   };
 
   const getItemQuantity = (productId: string) => {

--- a/src/data/simpleProducts.ts
+++ b/src/data/simpleProducts.ts
@@ -6,6 +6,7 @@ export const simpleProducts: Product[] = [
     id: '1',
     name: 'Premium Japanese Sneakers',
     slug: 'premium-japanese-sneakers',
+    shortDescription: 'Sneakers Nhật Bản cao cấp, êm ái và thời trang.',
     description: 'High-quality sneakers from Japan with excellent comfort and style.',
     sellingPrice: 2500000,
     originalPrice: 3000000,
@@ -16,9 +17,16 @@ export const simpleProducts: Product[] = [
       {
         id: 'img-1',
         url: '/lovable-uploads/078a129e-0f98-4d91-af61-873687db1a04.png',
-        alt: 'Premium Japanese Sneakers',
+        alt: 'Premium Japanese Sneakers - Primary',
         isPrimary: true,
         order: 1
+      },
+      {
+        id: 'img-1b',
+        url: '/lovable-uploads/078a129e-0f98-4d91-af61-873687db1a04.png',
+        alt: 'Premium Japanese Sneakers - Side',
+        isPrimary: false,
+        order: 2
       }
     ],
     category: {
@@ -31,6 +39,13 @@ export const simpleProducts: Product[] = [
     },
     origin: 'japan',
     status: 'available',
+    specifications: [
+      { label: 'Chất liệu', value: 'Vải dệt + Cao su' },
+      { label: 'Màu sắc', value: 'Trắng/Đen' },
+      { label: 'Trọng lượng', value: '0.9 kg' },
+      { label: 'Bảo hành', value: '12 tháng' }
+    ],
+    sourceUrl: 'https://japan-store.com/premium-sneakers',
     rating: {
       average: 4.5,
       count: 128
@@ -46,6 +61,7 @@ export const simpleProducts: Product[] = [
   {
     id: '2',
     name: 'Korean Beauty Set',
+    shortDescription: 'Bộ skincare Hàn Quốc đầy đủ cho làn da rạng rỡ.',
     slug: 'korean-beauty-set',
     description: 'Complete Korean skincare set for glowing skin.',
     sellingPrice: 1800000,
@@ -57,9 +73,16 @@ export const simpleProducts: Product[] = [
       {
         id: 'img-2',
         url: '/lovable-uploads/11e92b89-ed02-453a-9888-56cd91807f2d.png',
-        alt: 'Korean Beauty Set',
+        alt: 'Korean Beauty Set - Primary',
         isPrimary: true,
         order: 1
+      },
+      {
+        id: 'img-2b',
+        url: '/lovable-uploads/11e92b89-ed02-453a-9888-56cd91807f2d.png',
+        alt: 'Korean Beauty Set - Items',
+        isPrimary: false,
+        order: 2
       }
     ],
     category: {
@@ -72,6 +95,12 @@ export const simpleProducts: Product[] = [
     },
     origin: 'korea',
     status: 'available',
+    specifications: [
+      { label: 'Loại da', value: 'Mọi loại da' },
+      { label: 'Quy cách', value: '5 sản phẩm/skincare routine' },
+      { label: 'HSD', value: '36 tháng' }
+    ],
+    sourceUrl: 'https://korea-beauty.com/beauty-set',
     rating: {
       average: 4.8,
       count: 95
@@ -87,6 +116,7 @@ export const simpleProducts: Product[] = [
   {
     id: '3',
     name: 'American Tech Gadget',
+    shortDescription: 'Thiết bị công nghệ từ Mỹ với tính năng cao cấp.',
     slug: 'american-tech-gadget',
     description: 'Latest technology gadget from the USA with premium features.',
     sellingPrice: 3500000,
@@ -98,9 +128,16 @@ export const simpleProducts: Product[] = [
       {
         id: 'img-3',
         url: '/lovable-uploads/14ea3fe0-19d6-425c-b95b-4117bc41f3ca.png',
-        alt: 'American Tech Gadget',
+        alt: 'American Tech Gadget - Primary',
         isPrimary: true,
         order: 1
+      },
+      {
+        id: 'img-3b',
+        url: '/lovable-uploads/14ea3fe0-19d6-425c-b95b-4117bc41f3ca.png',
+        alt: 'American Tech Gadget - Back',
+        isPrimary: false,
+        order: 2
       }
     ],
     category: {
@@ -113,6 +150,12 @@ export const simpleProducts: Product[] = [
     },
     origin: 'usa',
     status: 'available',
+    specifications: [
+      { label: 'Kết nối', value: 'Wi-Fi, Bluetooth' },
+      { label: 'Nguồn', value: 'Pin sạc USB-C' },
+      { label: 'Bảo hành', value: '12 tháng' }
+    ],
+    sourceUrl: 'https://usa-tech.com/gadget',
     rating: {
       average: 4.3,
       count: 67
@@ -128,6 +171,7 @@ export const simpleProducts: Product[] = [
   {
     id: '4',
     name: 'European Fashion Watch',
+    shortDescription: 'Đồng hồ thời trang châu Âu thiết kế tinh xảo.',
     slug: 'european-fashion-watch',
     description: 'Elegant European watch with sophisticated design.',
     sellingPrice: 5200000,
@@ -139,9 +183,16 @@ export const simpleProducts: Product[] = [
       {
         id: 'img-4',
         url: '/lovable-uploads/1cd5a3da-7a58-4374-abc1-d7b02b0c5fd5.png',
-        alt: 'European Fashion Watch',
+        alt: 'European Fashion Watch - Primary',
         isPrimary: true,
         order: 1
+      },
+      {
+        id: 'img-4b',
+        url: '/lovable-uploads/1cd5a3da-7a58-4374-abc1-d7b02b0c5fd5.png',
+        alt: 'European Fashion Watch - Closeup',
+        isPrimary: false,
+        order: 2
       }
     ],
     category: {
@@ -154,6 +205,12 @@ export const simpleProducts: Product[] = [
     },
     origin: 'europe',
     status: 'available',
+    specifications: [
+      { label: 'Chống nước', value: '5 ATM' },
+      { label: 'Chất liệu dây', value: 'Da thật' },
+      { label: 'Đường kính mặt', value: '40 mm' }
+    ],
+    sourceUrl: 'https://europe-fashion.com/watch',
     rating: {
       average: 4.7,
       count: 143
@@ -169,6 +226,7 @@ export const simpleProducts: Product[] = [
   {
     id: '5',
     name: 'Japanese Gaming Console',
+    shortDescription: 'Máy chơi game Nhật Bản với hệ game độc quyền.',
     slug: 'japanese-gaming-console',
     description: 'Latest gaming console from Japan with exclusive games.',
     sellingPrice: 8500000,
@@ -180,9 +238,16 @@ export const simpleProducts: Product[] = [
       {
         id: 'img-5',
         url: '/lovable-uploads/30473baa-85f4-4931-aad9-c722ae7a4918.png',
-        alt: 'Japanese Gaming Console',
+        alt: 'Japanese Gaming Console - Primary',
         isPrimary: true,
         order: 1
+      },
+      {
+        id: 'img-5b',
+        url: '/lovable-uploads/30473baa-85f4-4931-aad9-c722ae7a4918.png',
+        alt: 'Japanese Gaming Console - Ports',
+        isPrimary: false,
+        order: 2
       }
     ],
     category: {
@@ -195,6 +260,11 @@ export const simpleProducts: Product[] = [
     },
     origin: 'japan',
     status: 'preorder',
+    specifications: [
+      { label: 'Bộ nhớ', value: '1 TB' },
+      { label: 'Kết nối', value: 'HDMI 2.1, Wi‑Fi 6' }
+    ],
+    sourceUrl: 'https://japan-games.com/console',
     rating: {
       average: 4.9,
       count: 234
@@ -210,6 +280,7 @@ export const simpleProducts: Product[] = [
   {
     id: '6',
     name: 'Korean Home Appliance',
+    shortDescription: 'Thiết bị gia dụng thông minh công nghệ Hàn Quốc.',
     slug: 'korean-home-appliance',
     description: 'Smart home appliance with advanced Korean technology.',
     sellingPrice: 4200000,
@@ -221,9 +292,16 @@ export const simpleProducts: Product[] = [
       {
         id: 'img-6',
         url: '/lovable-uploads/39605e90-8478-4fee-b1b9-cee41df66f10.png',
-        alt: 'Korean Home Appliance',
+        alt: 'Korean Home Appliance - Primary',
         isPrimary: true,
         order: 1
+      },
+      {
+        id: 'img-6b',
+        url: '/lovable-uploads/39605e90-8478-4fee-b1b9-cee41df66f10.png',
+        alt: 'Korean Home Appliance - Usage',
+        isPrimary: false,
+        order: 2
       }
     ],
     category: {
@@ -236,6 +314,12 @@ export const simpleProducts: Product[] = [
     },
     origin: 'korea',
     status: 'available',
+    specifications: [
+      { label: 'Công suất', value: '1200 W' },
+      { label: 'Điện áp', value: '220V' },
+      { label: 'Kích thước', value: '450 × 300 × 200 mm' }
+    ],
+    sourceUrl: 'https://korea-home.com/appliance',
     rating: {
       average: 4.4,
       count: 89
@@ -251,6 +335,7 @@ export const simpleProducts: Product[] = [
   {
     id: '7',
     name: 'USA Premium Headphones',
+    shortDescription: 'Tai nghe cao cấp từ Mỹ, âm thanh trung thực.',
     slug: 'usa-premium-headphones',
     description: 'High-quality headphones with premium sound from USA.',
     sellingPrice: 3200000,
@@ -262,9 +347,16 @@ export const simpleProducts: Product[] = [
       {
         id: 'img-7',
         url: '/lovable-uploads/39671993-1bb4-4bb6-8819-3ca5c07c0042.png',
-        alt: 'USA Premium Headphones',
+        alt: 'USA Premium Headphones - Primary',
         isPrimary: true,
         order: 1
+      },
+      {
+        id: 'img-7b',
+        url: '/lovable-uploads/39671993-1bb4-4bb6-8819-3ca5c07c0042.png',
+        alt: 'USA Premium Headphones - Side',
+        isPrimary: false,
+        order: 2
       }
     ],
     category: {
@@ -277,6 +369,12 @@ export const simpleProducts: Product[] = [
     },
     origin: 'usa',
     status: 'out_of_stock',
+    specifications: [
+      { label: 'Driver', value: '40 mm' },
+      { label: 'Kết nối', value: 'Bluetooth 5.3' },
+      { label: 'Thời lượng pin', value: '30 giờ' }
+    ],
+    sourceUrl: 'https://usa-audio.com/premium-headphones',
     rating: {
       average: 4.6,
       count: 156
@@ -292,6 +390,7 @@ export const simpleProducts: Product[] = [
   {
     id: '8',
     name: 'European Luxury Bag',
+    shortDescription: 'Túi xách cao cấp châu Âu, chất liệu thượng hạng.',
     slug: 'european-luxury-bag',
     description: 'Designer luxury bag from Europe with premium materials.',
     sellingPrice: 6800000,
@@ -303,9 +402,16 @@ export const simpleProducts: Product[] = [
       {
         id: 'img-8',
         url: '/lovable-uploads/3de85ddd-15e1-4216-9697-f91abb9a47ce.png',
-        alt: 'European Luxury Bag',
+        alt: 'European Luxury Bag - Primary',
         isPrimary: true,
         order: 1
+      },
+      {
+        id: 'img-8b',
+        url: '/lovable-uploads/3de85ddd-15e1-4216-9697-f91abb9a47ce.png',
+        alt: 'European Luxury Bag - Detail',
+        isPrimary: false,
+        order: 2
       }
     ],
     category: {
@@ -318,6 +424,12 @@ export const simpleProducts: Product[] = [
     },
     origin: 'europe',
     status: 'available',
+    specifications: [
+      { label: 'Chất liệu', value: 'Da thật' },
+      { label: 'Kích thước', value: '28 × 20 × 10 cm' },
+      { label: 'Màu sắc', value: 'Be/Nâu' }
+    ],
+    sourceUrl: 'https://europe-luxury.com/bag',
     rating: {
       average: 4.8,
       count: 78

--- a/src/pages/ProductDetail.tsx
+++ b/src/pages/ProductDetail.tsx
@@ -214,7 +214,7 @@ const ProductDetail: React.FC = () => {
                   onClick={() => navigate(-1)}
                 >
                   <ArrowLeft className="w-4 h-4 mr-2" />
-                  Back
+                  {t('productDetail.back')}
                 </Button>
                 <Button 
                   variant="outline" 
@@ -232,7 +232,7 @@ const ProductDetail: React.FC = () => {
                   }}
                 >
                   <Share2 className="w-4 h-4 mr-2" />
-                  Share
+                  {t('productDetail.share')}
                 </Button>
                 <Button
                   variant="outline"
@@ -245,7 +245,7 @@ const ProductDetail: React.FC = () => {
                   }}
                 >
                   <Copy className="w-4 h-4 mr-2" />
-                  Compare
+                  {t('productDetail.compare')}
                 </Button>
               </div>
             </div>
@@ -266,17 +266,17 @@ const ProductDetail: React.FC = () => {
                     {product.name}
                   </h1>
                   <div className="flex items-center space-x-4 text-sm text-gray-600 flex-wrap">
-                    <span>Brand: {product.brand?.name || 'Unknown'}</span>
+                    <span>{t('productDetail.brand')}: {product.brand?.name || 'Unknown'}</span>
                     {product.category && (
                       <>
                         <span>•</span>
-                        <span>Category: {product.category.name}</span>
+                        <span>{t('productDetail.category')}: {product.category.name}</span>
                       </>
                     )}
                     <span>•</span>
-                    <span>Origin: {product.origin.toUpperCase()}</span>
+                    <span>{t('productDetail.origin')}: {product.origin.toUpperCase()}</span>
                     <span>•</span>
-                    <span>SKU: {product.sku}</span>
+                    <span>{t('productDetail.sku')}: {product.sku}</span>
                   </div>
                 </div>
 
@@ -287,14 +287,14 @@ const ProductDetail: React.FC = () => {
                   </div>
                   {currentPrice !== product.sellingPrice && (
                     <div className="text-sm text-gray-500">
-                      Base price: {product.sellingPrice.toLocaleString('vi-VN')} {product.currency}
+                      {t('productDetail.price.base')}: {product.sellingPrice.toLocaleString('vi-VN')} {product.currency}
                     </div>
                   )}
                   {product.originalPrice && (
-                    <div className="text-sm text-gray-600">
-                      Original: ${product.originalPrice}
-                    </div>
-                  )}
+                      <div className="text-sm text-gray-600">
+                        {t('productDetail.price.original')}: {product.originalPrice.toLocaleString('vi-VN')} {product.currency}
+                      </div>
+                    )}
                 </div>
 
                 {/* Status & Stock */}
@@ -304,10 +304,14 @@ const ProductDetail: React.FC = () => {
                       ? 'bg-green-100 text-green-800'
                       : 'bg-yellow-100 text-yellow-800'
                   }`}>
-                    {product.status === 'available' ? '✅ In Stock' : '⏳ Preorder'}
+                    {product.status === 'available'
+                      ? t('productDetail.status.available')
+                      : product.status === 'preorder'
+                        ? t('productDetail.status.preorder')
+                        : t('productDetail.status.out_of_stock')}
                   </span>
                   <span className="text-sm text-gray-600">
-                    {product.stock} units available
+                    {t('productDetail.stock', { count: product.stock })}
                   </span>
                 </div>
 
@@ -324,7 +328,7 @@ const ProductDetail: React.FC = () => {
                     ))}
                   </div>
                   <span className="text-sm text-gray-600">
-                    {product.rating.average}/5 ({product.rating.count} reviews)
+                    {product.rating.average}/5 ({product.rating.count} {t('productDetail.reviews')})
                   </span>
                 </div>
 
@@ -344,7 +348,7 @@ const ProductDetail: React.FC = () => {
 
                 {/* Description */}
                 <div>
-                  <h3 className="text-lg font-medium text-gray-900 mb-2">Description</h3>
+                  <h3 className="text-lg font-medium text-gray-900 mb-2">{t('productDetail.description')}</h3>
                   <p className="text-gray-600 leading-relaxed mb-4">
                     {product.description}
                   </p>
@@ -356,7 +360,7 @@ const ProductDetail: React.FC = () => {
                 {/* Tags */}
                 {product.tags.length > 0 && (
                   <div>
-                    <h3 className="text-lg font-medium text-gray-900 mb-2">Tags</h3>
+                    <h3 className="text-lg font-medium text-gray-900 mb-2">{t('productDetail.tags')}</h3>
                     <div className="flex flex-wrap gap-2">
                       {product.tags.map((tag, index) => (
                         <span key={index} className="px-3 py-1 bg-blue-100 text-blue-800 text-sm rounded-full">
@@ -374,7 +378,7 @@ const ProductDetail: React.FC = () => {
                   {/* Quantity Selector */}
                   <div>
                     <label className="block text-sm font-medium text-gray-700 mb-2">
-                      Quantity
+                      {t('productDetail.quantity')}
                     </label>
                     <div className="flex items-center space-x-3">
                       <Button
@@ -404,7 +408,7 @@ const ProductDetail: React.FC = () => {
                       </Button>
                       
                       <span className="text-sm text-gray-500 ml-4">
-                        {product.stock > 0 ? `${product.stock} available` : 'Out of stock'}
+                        {product.stock > 0 ? t('productDetail.stock', { count: product.stock }) : t('productDetail.outOfStock')}
                       </span>
                     </div>
                   </div>
@@ -418,7 +422,7 @@ const ProductDetail: React.FC = () => {
                     onClick={handleAddToCart}
                     disabled={product.stock <= 0}
                   >
-                    {product.stock > 0 ? 'Add to Cart' : 'Out of Stock'}
+                    {product.stock > 0 ? t('productDetail.addToCart') : t('productDetail.outOfStock')}
                   </EnhancedButton>
 
                   {/* Current cart status */}
@@ -432,7 +436,7 @@ const ProductDetail: React.FC = () => {
 
                   {/* Total Price */}
                   <div className="text-center p-3 bg-gray-50 rounded">
-                    <div className="text-sm text-gray-600">Total Price</div>
+                    <div className="text-sm text-gray-600">{t('productDetail.price.total')}</div>
                     <div className="text-2xl font-bold text-gsa-primary">
                       {(currentPrice * quantity).toLocaleString('vi-VN')} {product.currency}
                     </div>
@@ -474,7 +478,7 @@ const ProductDetail: React.FC = () => {
         <div className="max-w-7xl mx-auto">
           <div className="flex items-center justify-between gap-3">
             <div className="min-w-0">
-              <div className="text-xs text-gray-500">Total</div>
+              <div className="text-xs text-gray-500">{t('productDetail.total')}</div>
               <div className="text-lg font-bold text-gsa-primary truncate">{(currentPrice * quantity).toLocaleString('vi-VN')} {product.currency}</div>
             </div>
             <EnhancedButton
@@ -485,7 +489,7 @@ const ProductDetail: React.FC = () => {
               onClick={handleAddToCart}
               disabled={product.stock <= 0}
             >
-              {product.stock > 0 ? 'Add to Cart' : 'Out of Stock'}
+              {product.stock > 0 ? t('productDetail.addToCart') : t('productDetail.outOfStock')}
             </EnhancedButton>
           </div>
         </div>

--- a/src/pages/Wishlist.tsx
+++ b/src/pages/Wishlist.tsx
@@ -15,13 +15,18 @@ const WishlistPage: React.FC = () => {
   return (
     <PageLayout>
       <div className="container mx-auto px-4 py-8">
-        <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center justify-between mb-2">
           <h1 className="text-3xl font-bold text-gray-900">Wishlist</h1>
           {items.length > 0 && (
             <Button variant="outline" onClick={clearWishlist}>
               <Trash2 className="w-4 h-4 mr-2" /> Clear all
             </Button>
           )}
+        </div>
+
+        {/* Local storage note */}
+        <div className="mb-6 p-3 bg-blue-50 border border-blue-100 rounded text-sm text-blue-700">
+          Danh sách yêu thích được lưu cục bộ trên trình duyệt này. Bạn có thể thêm sản phẩm từ trang Sản phẩm.
         </div>
 
         {items.length === 0 ? (

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -162,7 +162,33 @@
     "avgRating": "Avg Rating",
     "viewAllRelated": "View all related products",
     "alsoViewed": "Customers also viewed",
-    "recommendedForYou": "Recommended for you"
+    "recommendedForYou": "Recommended for you",
+
+    "back": "Back",
+    "share": "Share",
+    "compare": "Compare",
+    "brand": "Brand",
+    "category": "Category",
+    "origin": "Origin",
+    "sku": "SKU",
+    "price": {
+      "base": "Base price",
+      "original": "Original",
+      "total": "Total Price"
+    },
+    "status": {
+      "available": "✅ In Stock",
+      "preorder": "⏳ Preorder",
+      "out_of_stock": "❌ Out of stock"
+    },
+    "stock": "{{count}} units available",
+    "quantity": "Quantity",
+    "addToCart": "Add to Cart",
+    "outOfStock": "Out of Stock",
+    "description": "Description",
+    "tags": "Tags",
+    "reviews": "reviews",
+    "total": "Total"
   },
   "cart": {
     "title": "Shopping Cart",

--- a/src/translations/vi.json
+++ b/src/translations/vi.json
@@ -162,7 +162,33 @@
     "avgRating": "Đánh giá TB",
     "viewAllRelated": "Xem tất cả sản phẩm liên quan",
     "alsoViewed": "Khách hàng cũng xem",
-    "recommendedForYou": "Gợi ý cho bạn"
+    "recommendedForYou": "Gợi ý cho bạn",
+
+    "back": "Quay lại",
+    "share": "Chia sẻ",
+    "compare": "So sánh",
+    "brand": "Thương hiệu",
+    "category": "Danh mục",
+    "origin": "Xuất xứ",
+    "sku": "Mã SKU",
+    "price": {
+      "base": "Giá cơ bản",
+      "original": "Giá gốc",
+      "total": "Tổng tiền"
+    },
+    "status": {
+      "available": "✅ Còn hàng",
+      "preorder": "⏳ Đặt trước",
+      "out_of_stock": "❌ Hết hàng"
+    },
+    "stock": "Còn {{count}} sản phẩm",
+    "quantity": "Số lượng",
+    "addToCart": "Thêm vào giỏ",
+    "outOfStock": "Hết hàng",
+    "description": "Mô tả",
+    "tags": "Từ khóa",
+    "reviews": "đánh giá",
+    "total": "Tổng"
   },
   "cart": {
     "title": "Giỏ hàng",


### PR DESCRIPTION
This PR improves UX and content across wishlist/cart, product content, and localizes ProductDetail UI.\n\nWhat's included\n- Wishlist: add info banner about local storage (data persistence on current browser).\n- Cart: add subtle local-storage notice in sidebar header; translate cart toasts to Vietnamese for consistency.\n- Product data enrichment: add shortDescription, specifications, extra images, and sourceUrl to simpleProducts for a richer ProductDetail view.\n- ProductDetail UI localization: buttons (Back, Share, Compare, Add to Cart), labels (Brand/Category/Origin/SKU), status badges, pricing labels (base/original/total), stock text, Quantity, Description, Tags, and mobile Total.\n\nNotes\n- No API changes. Build & unit tests previously green on main.\n- Added i18n keys under productDetail.* in vi/en with English fallback.